### PR TITLE
docs(magneto): #MO-375 delete line break from introduction

### DIFF
--- a/application/magneto.md
+++ b/application/magneto.md
@@ -1,8 +1,6 @@
 # Magneto
 
-Que ce soit pour préparer des exposés ou des cours, quoi de mieux que de pouvoir agréger tout type de contenus sur un tableau ? Le principe est simple : sur un tableau blanc, ajouter des aimants contenant du contenu multimédia, texte, lien le tout de façon collaborative et en temps réel.
-
-Ces tableaux Magnéto disposent d’une barre de création permettant l’ajout de différents types de contenus y compris du contenu en provenance d’autres tableaux. Une extension web permet également d’agréger du contenu directement pendant sa navigation.
+Que ce soit pour préparer des exposés ou des cours, quoi de mieux que de pouvoir agréger tout type de contenus sur un tableau ? Le principe est simple : sur un tableau blanc, ajouter des aimants contenant du contenu multimédia, texte, lien le tout de façon collaborative et en temps réel. Ces tableaux Magnéto disposent d’une barre de création permettant l’ajout de différents types de contenus y compris du contenu en provenance d’autres tableaux. Une extension web permet également d’agréger du contenu directement pendant sa navigation.
 
 ## Créer un tableau
 


### PR DESCRIPTION
Bonjour,

Nous avons mis à jour l'aide en ligne de Magnéto pour éviter le problème du double affichage du sommaire, en remettant le paragraphe d'introduction sur une seule ligne. Nous avons donc juste supprimé un retour chariot. 

Pouvez vous l'accepter svp ? 

Merci beaucoup, 